### PR TITLE
PHOENIX-646: Improve PR template GitHub

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -13,27 +13,24 @@
 **Something you need to inform your reviewers about**
 
 -   [ ] This change requires a documentation update
--   [ ] This change requires existing unit tests update
+-   [ ] This change requires a unit tests update
 
 ## 🧪 QA Process
 
 **Details a QA process to the reviewers**
 
-### ✅ Nominal scenario
+### ✅ Positive testing (should succeed)
 
--   [ ] ...
+-   ...
 
-### ❌ Non-nominal scenario
+### ❌ Negative testing (should fail)
 
--   [ ] ...
+-   ...
 
 ## 👌 To check
 
 -   [ ] There's no regression
--   [ ] Coding guidelines are followed
-
-    -   [Contributing](https://github.com/phantombuster/engineering-docs/blob/master/contributing.md)
-    -   [Testing](https://github.com/phantombuster/engineering-docs/blob/master/testing.md)
+-   [ ] Coding guidelines are followed ([Contributing](https://github.com/phantombuster/engineering-docs/blob/master/contributing.md), [Testing](https://github.com/phantombuster/engineering-docs/blob/master/testing.md))
 
 ## 👥 Who needs to be notified after deployment
 


### PR DESCRIPTION
## 📝 What is this PR

-   [Specs](https://phantombuster.atlassian.net/browse/PHOENIX-646)

## 🏭 How does it work

The objective of this repository is to create a global PR template available for the whole PhantomBuster organization.
Following this process [creating-a-default-community-health-file](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).

This PR also aim to modify the previous PR template to fit better our needs.
Please provide in your review some example of what do you need for the new template.

## 🗒 Notes

⚠️ After this PR is merged, we should delete each `.github/pull_request_template.md` file in all our repository because they will override this new global template ⚠️
