### PR TITLE
docs: add informations for after deployment

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -32,6 +32,6 @@
 -   [ ] There's no regression
 -   [ ] Coding guidelines are followed ([Contributing](https://github.com/phantombuster/engineering-docs/blob/master/contributing.md), [Testing](https://github.com/phantombuster/engineering-docs/blob/master/testing.md))
 
-## 👥 Who needs to be notified after deployment
+## 🚀 What to do after deployment
 
-**Who should we notify after the deployment of this PR?**
+**Who should be notified after the deployment of this PR? What should be written in the changelog on Slack?**


### PR DESCRIPTION
## 📝 What is this PR

-   [Add information for after the release in the GitHub PR template](https://phantombuster.atlassian.net/browse/PHOENIX-656)

## 🏭 How does it work

Just update the markdown file

## 🧪 QA Process

Read the file and check for typo

## 🚀 What to do after deployment

The PLAT card should be updated 😊 